### PR TITLE
perf: 进一步优化了点技能的方式

### DIFF
--- a/module/umamusume/script/cultivate_task/cultivate.py
+++ b/module/umamusume/script/cultivate_task/cultivate.py
@@ -350,7 +350,7 @@ def script_cultivate_learn_skill(ctx: UmamusumeContext):
             img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
             if not compare_color_equal(img[1006, 701], [211, 209, 219]):
                 break
-            ctx.ctrl.swipe(x1=23, y1=1000, x2=23, y2=660, duration=1000, name="")
+            ctx.ctrl.swipe(x1=23, y1=1000, x2=23, y2=635, duration=1000, name="")
             time.sleep(1)
         while True:
             ctx.ctrl.swipe(x1=23, y1=620, x2=23, y2=1000, duration=100, name="")

--- a/module/umamusume/script/cultivate_task/cultivate.py
+++ b/module/umamusume/script/cultivate_task/cultivate.py
@@ -371,6 +371,8 @@ def script_cultivate_learn_skill(ctx: UmamusumeContext):
     target_skill_list = []
     curr_point = 0
     for i in range(len(learn_skill_list)+1):
+        if i > 0 and ctx.cultivate_detail.learn_skill_only_user_provided == True:
+            break
         for j in range(len(skill_list)):
             if skill_list[j]["priority"] != i or skill_list[j]["is_available"] == False:
                 continue

--- a/module/umamusume/script/cultivate_task/cultivate.py
+++ b/module/umamusume/script/cultivate_task/cultivate.py
@@ -342,6 +342,27 @@ def script_cultivate_learn_skill(ctx: UmamusumeContext):
             return
         else:
             learn_skill_list = [ctx.cultivate_detail.learn_skill_list]
+
+    #遍历整页, 找出所有可点的技能
+    skill_list = []
+    while True:
+        img = ctx.ctrl.get_screen()
+        l = get_skill_list(img,learn_skill_list)
+        #避免重复统计(会出现在页末翻页不完全的情况)
+        for i in l:
+            if i not in skill_list:
+                skill_list.append(i)
+        img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
+        if not compare_color_equal(img[1006, 701], [211, 209, 219]):
+            break
+        ctx.ctrl.swipe(x1=23, y1=1000, x2=23, y2=635, duration=1000, name="")
+        time.sleep(1)
+    #按照优先级排列
+    skill_list = sorted(skill_list,key = lambda x: x[2])
+    #当翻页时恰巧有一个技能名的一半出现在页面内, 可能会出现ocr识别错误成一个不存在的技能名的问题;
+    #不过这个问题几乎没有影响, 因为这个错误技能必然是最后被发现的, 加之它优先级一定是最低的, 所以只要不是
+    #技能点多到能把所有技能都点上, 就不会轮到这个错误技能被点
+    
     for i in range(len(learn_skill_list)):
         log.debug("目标技能列表：%s, 优先级：%s", str(learn_skill_list[i]), str(i))
         while True:

--- a/module/umamusume/script/cultivate_task/cultivate.py
+++ b/module/umamusume/script/cultivate_task/cultivate.py
@@ -378,7 +378,7 @@ def script_cultivate_learn_skill(ctx: UmamusumeContext):
                 curr_point += skill_list[j]["skill_cost"]
                 target_skill_list.append(skill_list[j]["skill_name"])
                 #如果点的是金色技能, 就将其绑定的下位技能设置为不可点
-                if skill_list[j]["is_gold"] == True:
+                if skill_list[j]["is_gold"] == True and skill_list[j]["subsequent_skill"] != '':
                     for k in range(len(skill_list)):
                         if skill_list[k]["skill_name"] == skill_list[j]["subsequent_skill"]:
                             skill_list[k]["is_available"] = False

--- a/module/umamusume/script/cultivate_task/cultivate.py
+++ b/module/umamusume/script/cultivate_task/cultivate.py
@@ -385,23 +385,20 @@ def script_cultivate_learn_skill(ctx: UmamusumeContext):
                         if skill_list[k]["skill_name"] == skill_list[j]["subsequent_skill"]:
                             skill_list[k]["is_available"] = False
 
-    #回到最顶部
-    while True:
-        ctx.ctrl.swipe(x1=23, y1=620, x2=23, y2=1000, duration=100, name="")
-        img = cv2.cvtColor(ctx.ctrl.get_screen(), cv2.COLOR_BGR2RGB)
-        if not compare_color_equal(img[488, 701], [211, 209, 219]):
-            time.sleep(1.5)
-            break
+    #向上移动至对齐
+    ctx.ctrl.swipe(x1=23, y1=950, x2=23, y2=968, duration=100, name="")
     time.sleep(1)
 
     #点技能
     while True:
         img = ctx.ctrl.get_screen()
         find_skill(ctx, img, target_skill_list, learn_any_skill=False)
-        img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
-        if not compare_color_equal(img[1006, 701], [211, 209, 219]):
+        if target_skill_list == []:
             break
-        ctx.ctrl.swipe(x1=23, y1=1000, x2=23, y2=636, duration=1000, name="")
+        img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
+        if not compare_color_equal(img[488, 701], [211, 209, 219]):
+            break
+        ctx.ctrl.swipe(x1=23, y1=636, x2=23, y2=1000, duration=1000, name="")
         time.sleep(1)
 
     ctx.cultivate_detail.learn_skill_done = True

--- a/module/umamusume/script/cultivate_task/cultivate.py
+++ b/module/umamusume/script/cultivate_task/cultivate.py
@@ -355,40 +355,53 @@ def script_cultivate_learn_skill(ctx: UmamusumeContext):
         img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
         if not compare_color_equal(img[1006, 701], [211, 209, 219]):
             break
-        ctx.ctrl.swipe(x1=23, y1=1000, x2=23, y2=635, duration=1000, name="")
+        ctx.ctrl.swipe(x1=23, y1=1000, x2=23, y2=636, duration=1000, name="")
         time.sleep(1)
-    #按照优先级排列
-    skill_list = sorted(skill_list,key = lambda x: x[2])
-    #当翻页时恰巧有一个技能名的一半出现在页面内, 可能会出现ocr识别错误成一个不存在的技能名的问题;
-    #不过这个问题几乎没有影响, 因为这个错误技能必然是最后被发现的, 加之它优先级一定是最低的, 所以只要不是
-    #技能点多到能把所有技能都点上, 就不会轮到这个错误技能被点
     
-    for i in range(len(learn_skill_list)):
-        log.debug("目标技能列表：%s, 优先级：%s", str(learn_skill_list[i]), str(i))
-        while True:
-            img = ctx.ctrl.get_screen()
-            find_skill(ctx, img, learn_skill_list[i], learn_any_skill=False)
-            img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
-            if not compare_color_equal(img[1006, 701], [211, 209, 219]):
-                break
-            ctx.ctrl.swipe(x1=23, y1=1000, x2=23, y2=635, duration=1000, name="")
-            time.sleep(1)
-        while True:
-            ctx.ctrl.swipe(x1=23, y1=620, x2=23, y2=1000, duration=100, name="")
-            img = cv2.cvtColor(ctx.ctrl.get_screen(), cv2.COLOR_BGR2RGB)
-            if not compare_color_equal(img[488, 701], [211, 209, 219]):
-                time.sleep(1.5)
-                break
+    #将金色技能和其后面的技能绑定
+    #TODO: 如果金色技能的下位技能在极端情况下被先点掉, 可能会导致技能绑定错误
+    for i in range(len(skill_list)):
+        if i != (len(skill_list)-1) and skill_list[i]["is_gold"] == True:
+            skill_list[i]["subsequent_skill"] = skill_list[i+1]["skill_name"]
+    
+    #按照优先级排列
+    skill_list = sorted(skill_list,key = lambda x: x["priority"])
+    #TODO: 暂时没办法处理一个技能可以点多次的情况
+    total_skill_point = int(re.sub("\\D", "", ocr_line(img[400: 440, 490: 665])))
+    target_skill_list = []
+    curr_point = 0
+    for i in range(len(learn_skill_list)+1):
+        for j in range(len(skill_list)):
+            if skill_list[j]["priority"] != i or skill_list[j]["is_available"] == False:
+                continue
+            if curr_point + skill_list[j]["skill_cost"] <= total_skill_point:
+                curr_point += skill_list[j]["skill_cost"]
+                target_skill_list.append(skill_list[j]["skill_name"])
+                #如果点的是金色技能, 就将其绑定的下位技能设置为不可点
+                if skill_list[j]["is_gold"] == True:
+                    for k in range(len(skill_list)):
+                        if skill_list[k]["skill_name"] == skill_list[j]["subsequent_skill"]:
+                            skill_list[k]["is_available"] = False
+
+    #回到最顶部
+    while True:
+        ctx.ctrl.swipe(x1=23, y1=620, x2=23, y2=1000, duration=100, name="")
+        img = cv2.cvtColor(ctx.ctrl.get_screen(), cv2.COLOR_BGR2RGB)
+        if not compare_color_equal(img[488, 701], [211, 209, 219]):
+            time.sleep(1.5)
+            break
     time.sleep(1)
-    if ctx.cultivate_detail.cultivate_finish or not ctx.cultivate_detail.learn_skill_only_user_provided:
-        while True:
-            img = ctx.ctrl.get_screen()
-            find_skill(ctx, img, [], learn_any_skill=True)
-            img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
-            if not compare_color_equal(img[1006, 701], [211, 209, 219]):
-                break
-            ctx.ctrl.swipe(x1=23, y1=1000, x2=23, y2=640, duration=1000, name="")
-            time.sleep(1)
+
+    #点技能
+    while True:
+        img = ctx.ctrl.get_screen()
+        find_skill(ctx, img, target_skill_list, learn_any_skill=False)
+        img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
+        if not compare_color_equal(img[1006, 701], [211, 209, 219]):
+            break
+        ctx.ctrl.swipe(x1=23, y1=1000, x2=23, y2=636, duration=1000, name="")
+        time.sleep(1)
+
     ctx.cultivate_detail.learn_skill_done = True
     ctx.cultivate_detail.turn_info.turn_learn_skill_done = True
 

--- a/module/umamusume/script/cultivate_task/parse.py
+++ b/module/umamusume/script/cultivate_task/parse.py
@@ -415,6 +415,7 @@ def find_skill(ctx: UmamusumeContext, img, skill: list[str], learn_any_skill: bo
                             if pt >= skill_pt_cost:
                                 ctx.ctrl.click(match_result.center_point[0] + 128, match_result.center_point[1],
                                                "加点技能：" + text)
+                                skill.remove(text)
                                 ctx.cultivate_detail.learn_skill_selected = True
                                 find = True
 

--- a/module/umamusume/script/cultivate_task/parse.py
+++ b/module/umamusume/script/cultivate_task/parse.py
@@ -446,10 +446,10 @@ def get_skill_list(img, skill: list[str]) -> list:
                     flag = False
                     for i in range(len(skill)):
                         if text in skill[i]:
-                            res.append((text,cost,i))
+                            res.append((text,int(cost),i))
                             flag = True
                     if flag == False:
-                        res.append((text,cost,len(skill)))
+                        res.append((text,int(cost),len(skill)))
             img[match_result.matched_area[0][1]:match_result.matched_area[1][1],
             match_result.matched_area[0][0]:match_result.matched_area[1][0]] = 0
 

--- a/module/umamusume/script/cultivate_task/parse.py
+++ b/module/umamusume/script/cultivate_task/parse.py
@@ -453,17 +453,25 @@ def get_skill_list(img, skill: list[str]) -> list:
                     flag = False
                     for i in range(len(skill)):
                         if text in skill[i]:
-                            res.append((text,int(cost),i,isGold,int(pos_center[1])))
+                            priority = i
                             flag = True
                     if flag == False:
-                        res.append((text,int(cost),len(skill),isGold,int(pos_center[1])))
+                        priority = len(skill)
+                    res.append({"skill_name":text,
+                                "skill_cost":int(cost),
+                                "priority":priority,
+                                "is_gold":isGold,
+                                "subsequent_skill":"",
+                                "is_available":True,
+                                "y_pos":int(pos_center[1])})
             img[match_result.matched_area[0][1]:match_result.matched_area[1][1],
             match_result.matched_area[0][0]:match_result.matched_area[1][0]] = 0
 
         else:
             break
+    res = sorted(res,key = lambda x : x["y_pos"])
     #没有精确计算过，但是大约y轴小于540就会导致技能名显示不全。暂时没测试出问题。
-    return [t[:-1] for t in sorted(res,key = lambda x : x[-1]) if t[-1] >= 540]
+    return [{k: v for k,v in r.items() if k != "y_pos"} for r in res if r["y_pos"] >= 540]
 
 def parse_factor(ctx: UmamusumeContext):
     origin_img = ctx.ctrl.get_screen()

--- a/module/umamusume/script/cultivate_task/parse.py
+++ b/module/umamusume/script/cultivate_task/parse.py
@@ -446,16 +446,17 @@ def get_skill_list(img, skill: list[str]) -> list:
                     flag = False
                     for i in range(len(skill)):
                         if text in skill[i]:
-                            res.append((text,int(cost),i))
+                            res.append((text,int(cost),i,int(pos_center[1])))
                             flag = True
                     if flag == False:
-                        res.append((text,int(cost),len(skill)))
+                        res.append((text,int(cost),len(skill),int(pos_center[1])))
             img[match_result.matched_area[0][1]:match_result.matched_area[1][1],
             match_result.matched_area[0][0]:match_result.matched_area[1][0]] = 0
 
         else:
             break
-    return res
+    #没有精确计算过，但是大约y轴小于540就会导致技能名显示不全。暂时没测试出问题。
+    return [t[:-1] for t in sorted(res,key = lambda x : x[3]) if t[-1] >= 540]
 
 def parse_factor(ctx: UmamusumeContext):
     origin_img = ctx.ctrl.get_screen()

--- a/module/umamusume/script/cultivate_task/parse.py
+++ b/module/umamusume/script/cultivate_task/parse.py
@@ -402,9 +402,7 @@ def find_skill(ctx: UmamusumeContext, img, skill: list[str], learn_any_skill: bo
                 skill_info_img = img[pos[0][1] - 65:pos[1][1] + 75, pos[0][0] - 470: pos[1][0] + 150]
                 if not image_match(skill_info_img, REF_SKILL_LEARNED).find_match:
                     skill_name_img = skill_info_img[10: 47, 100: 445]
-                    skill_cost_img = skill_info_img[65: 95, 520: 580]
                     text = ocr_line(skill_name_img)
-                    cost = ocr_line(skill_cost_img)
                     result = find_similar_text(text, skill, 0.7)
                     # print(text + "->" + result)
                     if result != "" or learn_any_skill:

--- a/module/umamusume/script/cultivate_task/parse.py
+++ b/module/umamusume/script/cultivate_task/parse.py
@@ -402,7 +402,9 @@ def find_skill(ctx: UmamusumeContext, img, skill: list[str], learn_any_skill: bo
                 skill_info_img = img[pos[0][1] - 65:pos[1][1] + 75, pos[0][0] - 470: pos[1][0] + 150]
                 if not image_match(skill_info_img, REF_SKILL_LEARNED).find_match:
                     skill_name_img = skill_info_img[10: 47, 100: 445]
+                    skill_cost_img = skill_info_img[65: 95, 520: 580]
                     text = ocr_line(skill_name_img)
+                    cost = ocr_line(skill_cost_img)
                     result = find_similar_text(text, skill, 0.7)
                     # print(text + "->" + result)
                     if result != "" or learn_any_skill:


### PR DESCRIPTION
## 优化
* 在点好一个技能后，就将其从待选列表中删除。在待选列表为空后就提前结束点技能阶段。
* 在遍历至页面底部后，返回页面顶的过程中就点好技能，可以节省半次页面遍历。

## 修复
* 修复了在金色技能意外绑定到空技能时，会错误地将所有其它技能标为不可选的问题。
* 修复了"育成中仅允许学习上面的技能"功能失效的问题