### PR TITLE
fix(bot\recog\ocr.py):change def ocr_line(img, lang="ch")

### DIFF
--- a/bot/recog/ocr.py
+++ b/bot/recog/ocr.py
@@ -19,11 +19,17 @@ def ocr(img, lang="ch"):
 # ocr_line 文字识别图片，返回所有出现的文字
 def ocr_line(img, lang="ch"):
     ocr_result = ocr(img, lang)
+
+    if ocr_result == [None]:
+        ocr_result = [[[[28.0, 23.0], [84.0, 23.0], [84.0, 47.0], [28.0, 47.0]], ('0', 0.9994117617607117)]]
+    else :
+        ocr_result = ocr_result[0]
+    
     text = ""
-    ocr_result = ocr_result[0]
     for text_info in ocr_result:
         if len(text_info) > 0:
             text += text_info[1][0]
+            print("提取的text_info:", text_info[1][0])
     return text
 
 


### PR DESCRIPTION
在使用中发现，在训练界面选中训练项目时，部分不会提升的属性对应的内容会识别为空列表，会产生如下错误导致程序中断： Traceback (most recent call last):
  File "D:\programs\git\UmamusumeAutoTrainer\bot\engine\executor.py", line 126, in run_work_flow
    manifest.script(ctx)
  File "D:\programs\git\UmamusumeAutoTrainer\module\umamusume\manifest.py", line 71, in exec_script
    script_dicts[ctx.task.task_type][ctx.current_ui](ctx)
  File "D:\programs\git\UmamusumeAutoTrainer\module\umamusume\script\cultivate_task\cultivate.py", line 107, in script_cultivate_training_select
    parse_training_result(ctx, img, train_type)
  File "D:\programs\git\UmamusumeAutoTrainer\module\umamusume\script\cultivate_task\parse.py", line 274, in parse_training_result
    speed_incr_text = ocr_line(sub_img_speed_incr)
  File "D:\programs\git\UmamusumeAutoTrainer\bot\recog\ocr.py", line 38, in ocr_line
    text += text_info[1][0]
TypeError: 'float' object is not subscriptable

通过在ocr_line函数中添加对空列表的判断并附一个标签为0的值可以简单地忽略这个问题